### PR TITLE
Convert port to int

### DIFF
--- a/generators/app/templates/src/index.ts
+++ b/generators/app/templates/src/index.ts
@@ -12,7 +12,7 @@ app.use("/api/weather", weatherRouter);
 
 // initialize the webserver
 const host = process.env.YOUR_HOST || "0.0.0.0";
-const port = process.env.PORT || 8080;
+const port = parseInt(process.env.PORT) || 8080;
 app.listen(port, host, () => {
     console.info(`App listening on port ${port}!`);
 });


### PR DESCRIPTION
The generator stopped working recently as typescript 2.9.2 complains about port being a string, but it has to be an int. The issue comes from the fact that all environment variables are strings.

The underlying issue is the (in my eyes) too permissive `package.json` - I suggest to lock to minor instead of major version.